### PR TITLE
linux改为使用firefox，以解决chromium在arm下可能产生的问题

### DIFF
--- a/nonebot_plugin_htmlrender/browser.py
+++ b/nonebot_plugin_htmlrender/browser.py
@@ -12,6 +12,7 @@ __author__ = "yanyongyu"
 
 from typing import Optional, AsyncIterator
 from contextlib import asynccontextmanager
+from sys import platform
 
 from nonebot.log import logger
 from playwright.async_api import Page, Error, Browser, Playwright, async_playwright
@@ -34,7 +35,10 @@ async def init(**kwargs) -> Browser:
 
 async def launch_browser(**kwargs) -> Browser:
     assert _playwright is not None, "Playwright is not initialized"
-    return await _playwright.chromium.launch(**kwargs)
+    if "win" in platform.lower():
+        return await _playwright.chromium.launch(**kwargs)
+    else:
+        return await _playwright.firefox.launch(**kwargs)
 
 
 async def get_browser(**kwargs) -> Browser:
@@ -59,13 +63,18 @@ async def shutdown_browser():
 
 
 async def install_browser():
-    logger.info("正在安装 chromium")
-    import sys
+    import sys,os
 
     from playwright.__main__ import main
-
-    sys.argv = ["", "install", "chromium"]
+    if "win" in platform.lower():
+        logger.info("正在安装 chromium")
+        sys.argv = ["", "install", "chromium"]
+    else:
+        logger.info("正在安装 firefox")
+        sys.argv = ["", "install", "firefox"]
     try:
+        logger.info("正在安装依赖")
+        os.system("playwright install-deps")
         main()
     except SystemExit:
         pass


### PR DESCRIPTION
微软在chromium的[build脚本](https://github.com/microsoft/playwright/blob/main/browser_patches/chromium/build.sh)中只构建了arm64，可能这是导致armv7报错的主要原因？
换成firefox则一切正常