### PR TITLE
:bug: 还原 get_browser 原有行为，降级 py3.9 不支持的语法

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,21 @@ dev = [
     "pytest-asyncio>=0.24.0",
 ]
 
+[tool.pyright]
+pythonVersion = "3.9"
+pythonPlatform = "All"
+defineConstant = { PYDANTIC_V2 = true }
+executionEnvironments = [
+  { root = "./tests", extraPaths = [
+    "./",
+  ] },
+  { root = "./" },
+]
+
+typeCheckingMode = "standard"
+reportShadowedImports = false
+disableBytesTypePromotions = true
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
你别说 Bison 真用到了`get_browser`
之前的pr把他变成同步函数，内部行为还变了(
以及为什么 `requires-python = ">=3.9,<4.0"`
但是用到了 `match-case`