### PR TITLE
:sparkles: feat: 支持通过 Playwright 协议连接浏览器

### DIFF
--- a/nonebot_plugin_htmlrender/browser.py
+++ b/nonebot_plugin_htmlrender/browser.py
@@ -117,6 +117,31 @@ async def _connect_via_cdp(**kwargs) -> Browser:
         raise RuntimeError("Playwright 未初始化")
 
 
+async def _connect(browser_type: str, **kwargs) -> Browser:
+    """
+    通过 Playwright 协议连接浏览器。
+
+    Args:
+        browser_type (str): 浏览器类型。
+        **kwargs: 传递给`playwright.connect`的关键字参数。
+
+    Returns:
+        Browser: 启动的浏览器实例。
+
+    Raises:
+        RuntimeError: 如果 Playwright 未初始化。
+    """
+    _browser_cls: BrowserType = getattr(_playwright, browser_type)
+    kwargs["ws_endpoint"] = plugin_config.htmlrender_connect
+    logger.info(
+        f"正在使用 Playwright 协议连接 {browser_type}({plugin_config.htmlrender_connect})"
+    )
+    if _playwright is not None:
+        return await _browser_cls.connect(**kwargs)
+    else:
+        raise RuntimeError("Playwright 未初始化")
+
+
 async def start_browser(**kwargs) -> Browser:
     """
     启动 Playwright 浏览器实例。
@@ -135,6 +160,9 @@ async def start_browser(**kwargs) -> Browser:
         and plugin_config.htmlrender_connect_over_cdp
     ):
         return await _connect_via_cdp(**kwargs)
+
+    if plugin_config.htmlrender_connect:
+        return await _connect(plugin_config.htmlrender_browser, **kwargs)
 
     if plugin_config.htmlrender_browser_channel:
         kwargs["channel"] = plugin_config.htmlrender_browser_channel

--- a/nonebot_plugin_htmlrender/config.py
+++ b/nonebot_plugin_htmlrender/config.py
@@ -36,6 +36,9 @@ class Config(BaseModel):
     htmlrender_connect_over_cdp: Optional[str] = Field(
         default=None, description="通过 CDP 连接Playwright浏览器的端点地址。"
     )
+    htmlrender_connect: Optional[str] = Field(
+        default=None, description="通过Playwright协议连接Playwright浏览器的端点地址。"
+    )
 
     @model_validator(mode="after")
     def check_browser_channel(self) -> Self:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -39,6 +39,7 @@ def browser_config() -> dict[str, str]:
     return {
         "browser": "chromium",
         "cdp": "ws://localhost:9222",
+        "pwp": "ws://localhost:3000/chromium/playwright",
     }
 
 
@@ -163,6 +164,29 @@ async def test_connect_via_cdp(
     mocker.patch(
         "nonebot_plugin_htmlrender.browser.plugin_config.htmlrender_connect_over_cdp",
         browser_config["cdp"],
+    )
+
+    browser = await start_browser()
+    assert browser == mock_browser
+
+
+@pytest.mark.asyncio
+async def test_connect(
+    mocker: MockerFixture, mock_browser: Browser, browser_config: dict[str, str]
+) -> None:
+    """测试通过Playwright协议连接浏览器"""
+    from nonebot_plugin_htmlrender.browser import start_browser
+
+    mocker.patch(
+        "nonebot_plugin_htmlrender.browser._connect", return_value=mock_browser
+    )
+    mocker.patch(
+        "nonebot_plugin_htmlrender.browser.plugin_config.htmlrender_browser",
+        browser_config["browser"],
+    )
+    mocker.patch(
+        "nonebot_plugin_htmlrender.browser.plugin_config.htmlrender_connect",
+        browser_config["pwp"],
     )
 
     browser = await start_browser()


### PR DESCRIPTION
运行以下代码即可启动一个 Playwright 协议浏览器：

```javascript
const { chromium } = require('playwright');

(async () => {
  const browserServer = await chromium.launchServer();
  const wsEndpoint = browserServer.wsEndpoint();
  console.log(wsEndpoint);
  await new Promise(() => {});
})();
```

参见：https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server