### PR TITLE
🐛 fix: 启动浏览器实例前关闭之前的实例

### DIFF
--- a/nonebot_plugin_htmlrender/browser.py
+++ b/nonebot_plugin_htmlrender/browser.py
@@ -13,7 +13,7 @@ from playwright.async_api import (
 
 from nonebot_plugin_htmlrender.config import plugin_config
 from nonebot_plugin_htmlrender.install import install_browser
-from nonebot_plugin_htmlrender.utils import proxy_settings, suppress_and_log
+from nonebot_plugin_htmlrender.utils import proxy_settings, suppress_and_log, with_lock
 
 _browser: Optional[Browser] = None
 _playwright: Optional[Playwright] = None
@@ -76,6 +76,7 @@ async def get_new_page(device_scale_factor: float = 2, **kwargs) -> AsyncIterato
         await page.close()
 
 
+@with_lock
 async def get_browser(**kwargs) -> Browser:
     """
     获取浏览器实例。
@@ -140,6 +141,7 @@ async def _connect(browser_type: str, **kwargs) -> Browser:
         raise RuntimeError("Playwright 未初始化")
 
 
+@with_lock
 async def start_browser(**kwargs) -> Browser:
     """
     启动 Playwright 浏览器实例。

--- a/nonebot_plugin_htmlrender/utils.py
+++ b/nonebot_plugin_htmlrender/utils.py
@@ -1,3 +1,5 @@
+from asyncio import Lock
+from collections.abc import Awaitable
 from contextlib import contextmanager
 from functools import wraps
 import re
@@ -146,3 +148,14 @@ def proxy_settings(proxy_host: Optional[str]) -> Optional[dict]:
         proxy["bypass"] = plugin_config.htmlrender_proxy_host_bypass
 
     return proxy
+
+
+def with_lock(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+    lock = Lock()
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs) -> R:
+        async with lock:
+            return await func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
不关闭之前的 Playwright 实例和浏览器可能会导致内存泄漏