### PR TITLE
:feat: CI 稳定性与跨平台支持增强：引入重试机制与 CI 模式、完善 Playwright 关闭流程、重构覆盖率工作流

### DIFF
--- a/.github/workflows/_test-os-arch.yml
+++ b/.github/workflows/_test-os-arch.yml
@@ -1,0 +1,67 @@
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test (Py ${{ inputs.python-version }} — ${{ matrix.os_label }})
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - runs_on: ubuntu-latest
+            os_label: ubuntu-latest x64
+            arch: x64
+            platform: linux
+
+          - runs_on: macos-latest
+            os_label: macos-latest arm64
+            arch: arm64
+            platform: macos
+
+          - runs_on: windows-latest
+            os_label: windows-latest x64
+            arch: x64
+            platform: windows
+
+          - runs_on: ubuntu-24.04-arm
+            os_label: ubuntu-24.04-arm arm64
+            arch: arm64
+            platform: linux
+
+    env:
+      OS: ${{ matrix.os_label }}
+      PYTHON_VERSION: ${{ inputs.python-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+          cache-suffix: ${{ matrix.runs_on }}-${{ inputs.python-version }}
+
+      - name: Sync deps
+        run: uv sync --locked --all-extras --dev
+
+      - name: Install Playwright (Linux)
+        if: matrix.platform == 'linux'
+        run: uv run playwright install --with-deps && uv run playwright install --with-deps
+      - name: Install Playwright (non-Linux)
+        if: matrix.platform != 'linux'
+        run: uv run playwright install && uv run playwright install
+
+      - name: Run tests
+        run: uv run pytest -s -n auto
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          env_vars: OS,PYTHON_VERSION
+          verbose: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,7 +2,7 @@ name: Code Coverage
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, dev , feat/*]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,42 +2,19 @@ name: Code Coverage
 
 on:
   push:
-    branches:
-      - "master"
-      - "dev"
+    branches: [ master, dev ]
   pull_request:
-    branches:
-      - "master"
+    branches: [ master ]
 
 jobs:
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}
+  per-python:
+    name: Python ${{ matrix.python-version }}
     strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
-    env:
-      OS: ${{ matrix.os }}
-      PYTHON_VERSION: ${{ matrix.python-version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          python-version: ${{ matrix.python-version }}
-
-      - run: uv sync
-        shell: bash
-
-      - name: Run tests
-        run: uv run pytest -s
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          env_vars: OS,PYTHON_VERSION
+    uses: ./.github/workflows/_test-os-arch.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+    secrets: inherit

--- a/nonebot_plugin_htmlrender/config.py
+++ b/nonebot_plugin_htmlrender/config.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 from nonebot import get_driver, get_plugin_config
 from nonebot.compat import model_validator
+from nonebot.log import logger
 import nonebot_plugin_localstore as store
 from pydantic import BaseModel, Field
 
@@ -31,6 +32,14 @@ class Config(BaseModel):
     htmlrender_config_path: Path = Field(
         default=plugin_config_dir,
         description="配置路径，不填则使用 `nonebot-plugin-localstore` 管理",
+    )
+    htmlrender_shutdown_browser_on_exit: bool = Field(
+        default=True,
+        description="在插件关闭时关闭浏览器实例，在连接到远程浏览器时默认为 False。",
+    )
+    htmlrender_ci_mode: bool = Field(
+        default=False,
+        description="启用CI模式，跳过浏览器安装和环境变量",
     )
     htmlrender_download_host: Optional[str] = Field(
         default=None, description="下载Playwright浏览器时的主机地址。"
@@ -93,3 +102,8 @@ class Config(BaseModel):
 
 global_config = get_driver().config
 plugin_config = get_plugin_config(Config)
+
+if plugin_config.htmlrender_ci_mode:
+    logger.info(
+        "CI mode enabled, skipping browser installation and environment variable setup."
+    )

--- a/nonebot_plugin_htmlrender/install.py
+++ b/nonebot_plugin_htmlrender/install.py
@@ -202,7 +202,7 @@ async def execute_install_command(timeout: int) -> tuple[bool, str]:
                 asyncio.gather(stdout_task, stderr_task), timeout=timeout
             )
         except asyncio.TimeoutError:
-            logger.error(f"Timed out ({timeout}秒)")
+            logger.error(f"Timed out ({timeout}s)")
             await terminate_process(process)
             return False, f"Timed out ({timeout}s)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-htmlrender"
-version = "0.6.8"
+version = "0.6.7"
 description = "通过浏览器渲染图片"
 readme = "README.md"
 authors = [{ name = "kexue", email = "x@kexue-cloud.cn" }]
@@ -16,6 +16,7 @@ dependencies = [
     "pygments>=2.10.0",
     "pymdown-extensions>=9.1",
     "python-markdown-math>=0.8",
+    "tenacity>=9.1.2",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import gc
+
+import anyio
 import nonebot
 from nonebug import NONEBOT_INIT_KWARGS
 import pytest
@@ -23,3 +26,17 @@ def pytest_collection_modifyitems(items: list[pytest.Item]):
 @pytest.fixture(scope="session", autouse=True)
 async def after_nonebot_init(after_nonebot_init: None):
     nonebot.require("nonebot_plugin_htmlrender")
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def _cleanup_playwright_session():
+    from nonebot_plugin_htmlrender import shutdown_htmlrender
+
+    yield
+
+    await shutdown_htmlrender()
+
+    gc.collect()
+    gc.collect()
+
+    await anyio.lowlevel.checkpoint()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,16 @@
 import nonebot
+from nonebug import NONEBOT_INIT_KWARGS
 import pytest
 from pytest_asyncio import is_async_test
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.stash[NONEBOT_INIT_KWARGS] = {
+        "superusers": {"10001"},
+        "command_start": {""},
+        "log_level": "DEBUG",
+        "htmlrender_ci_mode": True,
+    }
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]):

--- a/tests/test_htmlrender.py
+++ b/tests/test_htmlrender.py
@@ -152,7 +152,8 @@ async def test_capture_element(mocker: MockerFixture) -> None:
 
     mock_page = mocker.AsyncMock()
     mock_page.goto = mocker.AsyncMock()
-    mock_page.on = mocker.AsyncMock()
+    mock_page.on = mocker.MagicMock()
+    mock_page.off = mocker.MagicMock()
     mock_page.locator = mocker.MagicMock(return_value=mock_locator)
 
     mock_cm = mocker.MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -771,7 +771,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-htmlrender"
-version = "0.6.8"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -783,6 +783,7 @@ dependencies = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "python-markdown-math" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -808,6 +809,7 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.10.0" },
     { name = "pymdown-extensions", specifier = ">=9.1" },
     { name = "python-markdown-math", specifier = ">=0.8" },
+    { name = "tenacity", specifier = ">=9.1.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1490,6 +1492,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/b9/cc3017f9a9c9b6e27c5106cc10cc7904653c3eec0729793aec10479dd669/starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9", size = 2584144, upload-time = "2025-08-24T13:36:42.122Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51", size = 72991, upload-time = "2025-08-24T13:36:40.887Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 关键变更
- **新增依赖**
  - 引入 `tenacity>=9.1.2`，用于环境检查的重试控制。另：当前 `pyproject.toml` 中版本号从 `0.6.8` 变为 `0.6.7`，合并时建议直接 bump 至 **0.7.0**。
- **核心逻辑改进**
  - 为 Playwright 环境检查与连接流程加入 **重试机制**，并使用 `AsyncExitStack` 对浏览器与 Playwright 的关闭过程进行统一、可靠的收尾。
- **新增配置项**
  - `htmlrender_ci_mode`：启用后**跳过浏览器安装与环境变量设置**，专用于 CI 场景（默认 `False`，不影响现有用户）。
  - `htmlrender_shutdown_browser_on_exit`：控制插件关闭时是否回收浏览器实例（默认 `True`）。
- **测试增强**
  - 在 `pytest_configure` 中注入 `NONEBOT_INIT_KWARGS`，默认启用 `htmlrender_ci_mode=True` 以适配 CI。
  - 将 `mock_page.on/off` 调整为 `MagicMock`，避免异步 mock 的不必要开销与兼容性问题。
  - 新增 **session 级清理 fixture**：统一调用 `shutdown_htmlrender()`，并执行两次 `gc.collect()` 与 `anyio.lowlevel.checkpoint()`，减少 xdist/Windows 下的残留连接问题。
- **CI / 覆盖率工作流重构**
  - 新增可复用工作流 **`_test-os-arch.yml`**，覆盖 `ubuntu-latest x64 / ubuntu-24.04-arm arm64 / macos-latest arm64 / windows-latest x64`，并支持 **Python 3.9–3.13**。
  - `codecov.yml` 精简并改为调用上述复用工作流；对 **feature 分支（`feat/*`）** 也开启覆盖率上报。
  - Playwright 在 Linux 与非 Linux 环境分别安装，确保依赖完整。

## 兼容性
- 新增配置项均有合理默认值，**不开启 CI 模式时不改变现有行为**。若使用远程浏览器，默认将不关闭浏览器。
- **CI 环境**：通过 NoneBot 配置或环境变量启用 `htmlrender_ci_mode`，以加快流水线并减少环境波动。

## 版本发布建议
- 建议发布版本：**v0.7.0**
- 合并前请将 `pyproject.toml` 的 `version` 统一更新为 `0.7.0`（当前分支里为 `0.6.7`）。

## 清单
- [x] 引入 `tenacity` 并实现环境检查重试  
- [x] 新增 `htmlrender_ci_mode` 与 `htmlrender_shutdown_browser_on_exit`  
- [x] 完善关闭流程与日志  
- [x] 测试用例与清理逻辑完善  
- [x] 重构 Codecov 工作流与多 OS/Arch 支持  
- [ ] **合并前 bump 版本至 v0.7.0**