### PR TITLE
Release/v0.8.1

### DIFF
--- a/.github/actions/setup-skia-runtime/action.yml
+++ b/.github/actions/setup-skia-runtime/action.yml
@@ -1,0 +1,15 @@
+name: Set up Skia runtime
+description: Install the Linux shared libraries required by skia-python
+
+runs:
+  using: composite
+  steps:
+    - name: Install Skia runtime libraries
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends \
+          libegl1 \
+          libexpat1 \
+          libgl1

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,29 +11,56 @@ on:
       - completed
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact current master SHA whose untagged version should be recovered
+        required: true
+        type: string
 
 permissions: {}
 
 # Each required workflow emits a completion event. Serialize events for the same
 # source commit so only one run can create its tag or dispatch its publication.
 concurrency:
-  group: auto-tag-${{ github.event.workflow_run.head_sha }}
+  group: auto-tag-${{ github.event.workflow_run.head_sha || inputs.source_sha }}
   cancel-in-progress: false
 
 jobs:
   tag-and-dispatch:
     name: Gate source, tag version change & dispatch publish
     if: >-
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'master'
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'master') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       actions: write # Read source workflow runs and dispatch publish.yml.
       contents: write # Create the tag at the verified master commit.
     env:
-      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+      RECOVERY_MODE: ${{ github.event_name == 'workflow_dispatch' }}
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha || inputs.source_sha }}
     steps:
+      - name: Validate recovery request
+        if: env.RECOVERY_MODE == 'true'
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_TYPE}" != "branch" || "${REF_NAME}" != "${DEFAULT_BRANCH}" ]]; then
+            echo "::error::Pre-tag recovery must use the default branch workflow definition."
+            exit 1
+          fi
+          if [[ ! "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_sha must be a full lowercase commit SHA."
+            exit 1
+          fi
+
       - name: Require all release workflows for the exact source SHA
         id: gates
         shell: bash
@@ -115,7 +142,7 @@ jobs:
           version: "0.11.28"
           enable-cache: false
 
-      - name: Verify source and detect a version change
+      - name: Verify source and select the release version
         if: steps.gates.outputs.ready == 'true'
         id: version
         shell: bash
@@ -132,6 +159,11 @@ jobs:
             echo "::error::Gated source ${SOURCE_SHA} is not on master."
             exit 1
           fi
+          MASTER_SHA=$(git rev-parse origin/master)
+          if [[ "${RECOVERY_MODE}" == "true" && "${SOURCE_SHA}" != "${MASTER_SHA}" ]]; then
+            echo "::error::Pre-tag recovery requires current master ${MASTER_SHA}, got ${SOURCE_SHA}."
+            exit 1
+          fi
 
           if ! PARENT_SHA=$(git rev-parse --verify "${SOURCE_SHA}^1"); then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
@@ -146,18 +178,20 @@ jobs:
           PREVIOUS_VERSION=$(git show "${PARENT_SHA}:pyproject.toml" | python3 -c \
             'import sys, tomllib; print(tomllib.load(sys.stdin.buffer)["project"]["version"])')
           VERSION=$(uv version --short)
-          if [[ "${VERSION}" == "${PREVIOUS_VERSION}" ]]; then
+          if [[ "${VERSION}" == "${PREVIOUS_VERSION}" && "${RECOVERY_MODE}" != "true" ]]; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
             echo "Project version remains ${VERSION}; no release tag is needed."
             exit 0
           fi
 
-          uvx --from packaging==26.2 python - "${PREVIOUS_VERSION}" "${VERSION}" <<'PY'
+          uvx --from packaging==26.2 python - \
+            "${PREVIOUS_VERSION}" "${VERSION}" "${RECOVERY_MODE}" <<'PY'
           import sys
 
           from packaging.version import InvalidVersion, Version
 
-          previous_raw, current_raw = sys.argv[1:]
+          previous_raw, current_raw, recovery_raw = sys.argv[1:]
+          recovery = recovery_raw == "true"
           try:
               previous = Version(previous_raw)
               current = Version(current_raw)
@@ -171,7 +205,7 @@ jobs:
               )
           if current.local is not None:
               raise SystemExit("::error::PyPI releases cannot use a local version segment.")
-          if current <= previous:
+          if current < previous or (current == previous and not recovery):
               raise SystemExit(
                   f"::error::Automatic releases must increase the version: {previous} -> {current}.",
               )
@@ -188,13 +222,18 @@ jobs:
           echo "previous_version=${PREVIOUS_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
-          echo "Detected version change ${PREVIOUS_VERSION} -> ${VERSION}."
+          if [[ "${VERSION}" == "${PREVIOUS_VERSION}" ]]; then
+            echo "Recovering untagged version ${VERSION} from current master ${SOURCE_SHA}."
+          else
+            echo "Detected version change ${PREVIOUS_VERSION} -> ${VERSION}."
+          fi
 
       - name: Decide whether to create or reuse the tag
         if: steps.version.outputs.changed == 'true'
         id: tag
         shell: bash
         env:
+          RECOVERY_MODE: ${{ env.RECOVERY_MODE }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
@@ -207,11 +246,19 @@ jobs:
               echo "::error::Tag ${TAG} already points to ${TAG_SHA}, not ${SOURCE_SHA}."
               exit 1
             fi
+            if [[ "${RECOVERY_MODE}" == "true" ]]; then
+              echo "::error::Tag ${TAG} already exists; recover with Publish instead."
+              exit 1
+            fi
             echo "create=false" >> "${GITHUB_OUTPUT}"
             echo "Tag ${TAG} already points to ${SOURCE_SHA}; reusing it."
           else
             echo "create=true" >> "${GITHUB_OUTPUT}"
           fi
+
+      - name: Install Skia runtime libraries
+        if: steps.version.outputs.changed == 'true' && steps.tag.outputs.create == 'true'
+        uses: ./.github/actions/setup-skia-runtime
 
       - name: Build and validate release candidates before tagging
         if: steps.version.outputs.changed == 'true' && steps.tag.outputs.create == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,7 @@ jobs:
           cache-suffix: package-${{ github.event_name }}
 
       - name: Install Skia runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libegl1 \
-            libexpat1 \
-            libgl1
+        uses: ./.github/actions/setup-skia-runtime
 
       - name: Build distributions
         run: |
@@ -184,12 +179,7 @@ jobs:
           cache-suffix: package-wheel-${{ matrix.python-version }}-${{ github.event_name }}
 
       - name: Install Skia runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libegl1 \
-            libexpat1 \
-            libgl1
+        uses: ./.github/actions/setup-skia-runtime
 
       - name: Download built distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,12 +58,7 @@ jobs:
           cache-suffix: coverage-py${{ matrix.python-version }}-${{ matrix.target.arch }}
 
       - name: Install Skia runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libegl1 \
-            libexpat1 \
-            libgl1
+        uses: ./.github/actions/setup-skia-runtime
 
       - name: Show Runner Context
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,18 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - docs/**
-      - mkdocs.yml
-      - README.md
-      - pyproject.toml
-      - uv.lock
-      - .python-version
-      - Makefile
-      - .github/workflows/docs.yml
-      - .github/workflows/docs-pr-preview.yml
-      - .github/workflows/docs-pr-preview-deploy.yml
-      - .github/workflows/docs-pr-preview-cleanup.yml
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -32,6 +32,9 @@ jobs:
           version: "0.11.28"
           enable-cache: false
 
+      - name: Install Skia runtime libraries
+        uses: ./.github/actions/setup-skia-runtime
+
       - name: Compute a unique development version
         id: version
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,6 +124,9 @@ jobs:
           version: "0.11.28"
           enable-cache: false
 
+      - name: Install Skia runtime libraries
+        uses: ./.github/actions/setup-skia-runtime
+
       - name: Verify tag, source commit, version, and lockfile
         id: verify
         shell: bash

--- a/docs/project/ci.md
+++ b/docs/project/ci.md
@@ -22,9 +22,9 @@ tags:
 | Docs PR Preview Build | `.github/workflows/docs-pr-preview.yml` | 检测文档相关变更，以只读权限严格构建静态站 | PR open/sync/reopen |
 | Docs PR Preview Deploy | `.github/workflows/docs-pr-preview-deploy.yml` | 校验并发布 build artifact，更新 PR 预览评论 | preview build 完成 |
 | Docs PR Preview Cleanup | `.github/workflows/docs-pr-preview-cleanup.yml` | 删除已关闭 PR 的 Pages 预览 | PR closed |
-| Docs | `.github/workflows/docs.yml` | 对待发布源码执行严格文档构建，不写 Pages | push `master` 的文档相关路径、手动 |
+| Docs | `.github/workflows/docs.yml` | 对每个可能成为 release source 的 `master` SHA 执行严格文档构建，不写 Pages | push `master`、手动 |
 | Publish (TestPyPI) | `.github/workflows/publish-test.yml` | 构建唯一 dev version 并 trusted publish 到 TestPyPI | **仅手动** |
-| Auto Tag on Version Change | `.github/workflows/auto-tag.yml` | 汇合同一 master SHA 的 CI/Coverage/Docs/Prek，验证版本递增后 tag 并 dispatch `Publish` | 四条 required workflow 完成 |
+| Auto Tag on Version Change | `.github/workflows/auto-tag.yml` | 汇合同一 master SHA 的 CI/Coverage/Docs/Prek，验证版本递增后 tag 并 dispatch `Publish`；也提供受同等门禁约束的 pre-tag recovery | 四条 required workflow 完成、受约束的手动恢复 |
 | Publish | `.github/workflows/publish.yml` | 校验 tag/source/version，发布并回读 PyPI、创建 GitHub Release，最后部署对应 tag 的版本文档 | `v*` tag、受约束的手动恢复 |
 
 ## PR 必需质量层

--- a/docs/project/release.md
+++ b/docs/project/release.md
@@ -78,6 +78,8 @@ flowchart LR
 
 普通 PR、只修改依赖配置的 PR 或未改变 `project.version` 的 master commit 都不会创建 tag。版本更新必须位于最终 squash/merge commit，确保第一父提交与 gated source 的版本差异可审计。
 
+如果 Auto Tag 的构建 preflight 因 workflow 基础设施缺陷失败且尚未创建 tag，先通过 PR 修复基础设施，并等待修复后当前 `master` SHA 的 CI、Coverage、Docs、Prek 全部成功。随后从默认分支手动运行 `Auto Tag on Version Change`，输入该完整 `source_sha`。恢复入口只接受当前 `master` tip、重新汇合该精确 SHA 的四条门禁、要求目标 tag 尚不存在，并再次执行完整 package preflight；它不能用于已有 tag 的发布恢复，也不能选择历史 commit。已有 tag 应直接按下文重跑 `Publish`。
+
 由 `GITHUB_TOKEN` push 产生的事件不会再次触发普通 downstream workflow；显式 `workflow_dispatch` 是发布契约的一部分，也使同一 tag 的恢复可重复执行。
 
 ### Publish 的不可逆操作前校验
@@ -106,7 +108,7 @@ TestPyPI 用于安装行为或包元数据的人工验收，不是 PR 必需 che
 
 ## 文档是独立发布链路
 
-`Docs` 监听 `master` 上的文档、文档配置和文档工作流相关路径。版本字段位于 `pyproject.toml`，因此版本 PR 必然触发严格构建；其成功结果也是自动创建 tag 的精确 SHA 门禁之一，但它不写正式 Pages 版本。
+`Docs` 覆盖每个 `master` push，使正常 release cut 和 pre-tag recovery 选择的任意当前 `master` SHA 都具备可汇合的精确 SHA 门禁。它执行严格构建，但不写正式 Pages 版本。
 
 `Publish versioned documentation` 位于不可逆软件发布之后：它重新检出经过验证的 tag、再次 strict build，并在 PyPI hash 回读与 GitHub Release 均成功后才通过 `mike` 创建 `/<version>/` 和更新 `latest`。
 
@@ -125,6 +127,7 @@ TestPyPI 用于安装行为或包元数据的人工验收，不是 PR 必需 che
 
 | 状态                                         | 恢复方式                                                                                                                                      |
 | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Auto Tag package preflight 失败，尚未创建 tag | 基础设施缺陷先通过 PR 修复；四条 required workflow 在修复后的当前 `master` SHA 全部成功后，以该完整 SHA 手动运行 `Auto Tag on Version Change`；产物或 metadata 缺陷则提升版本并走新的版本 PR |
 | tag/source/version 不变量校验失败            | 停止发布并核对 tag 来源；代码或版本确有错误时发起新的版本 PR。除非维护者确认 tag 从未对外发布且明确承担历史变更风险，否则不要移动或重建原 tag |
 | build / `twine check` 失败，尚未上传 PyPI    | 基础设施瞬时故障可对同一 tag 重跑；产物或 metadata 确有错误时提升版本并走新的版本 PR                                                          |
 | 校验和构建成功，PyPI 因临时故障失败          | 对同一已验证 tag 重新运行 `Publish`                                                                                                           |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-htmlrender"
-version = "0.8.0"
+version = "0.8.1"
 description = "提供 HTML、Markdown、模板渲染与独立栅格场景能力"
 readme = "README.md"
 authors = [{ name = "kexue", email = "x@kexue-cloud.cn" }]

--- a/tests/architecture/test_release_workflow_contract.py
+++ b/tests/architecture/test_release_workflow_contract.py
@@ -1,0 +1,61 @@
+"""Contracts shared by release and distribution verification workflows."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+SKIA_ACTION = ROOT / ".github" / "actions" / "setup-skia-runtime" / "action.yml"
+SKIA_SETUP = "uses: ./.github/actions/setup-skia-runtime"
+
+
+def _workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def test_skia_runtime_action_owns_linux_dependencies() -> None:
+    action = SKIA_ACTION.read_text(encoding="utf-8")
+
+    assert "using: composite" in action
+    for package in ("libegl1", "libexpat1", "libgl1"):
+        assert package in action
+
+    for workflow in WORKFLOWS.glob("*.yml"):
+        assert "sudo apt-get install" not in workflow.read_text(encoding="utf-8")
+
+
+def test_all_skia_smoke_workflows_use_shared_runtime_setup() -> None:
+    expected_uses = {
+        "auto-tag.yml": 1,
+        "ci.yml": 2,
+        "coverage.yml": 1,
+        "publish-test.yml": 1,
+        "publish.yml": 1,
+    }
+
+    for workflow, count in expected_uses.items():
+        assert _workflow(workflow).count(SKIA_SETUP) == count
+
+
+def test_distribution_preflight_installs_skia_runtime_first() -> None:
+    for workflow in ("auto-tag.yml", "ci.yml", "publish-test.yml", "publish.yml"):
+        content = _workflow(workflow)
+        assert "make verify-artifacts" in content
+        assert content.index(SKIA_SETUP) < content.index("make verify-artifacts")
+
+
+def test_pre_tag_recovery_preserves_release_gates() -> None:
+    workflow = _workflow("auto-tag.yml")
+    docs_trigger = _workflow("docs.yml").partition("permissions:")[0]
+
+    assert "workflow_dispatch:" in workflow
+    assert "source_sha:" in workflow
+    assert '"${SOURCE_SHA}" != "${MASTER_SHA}"' in workflow
+    assert "Tag ${TAG} already exists; recover with Publish instead." in workflow
+    assert "paths:" not in docs_trigger
+    for required in (
+        "CI:ci.yml",
+        "Coverage:coverage.yml",
+        "Docs:docs.yml",
+        "Prek:prek.yml",
+    ):
+        assert required in workflow

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-htmlrender"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## 背景

v0.8.0 合并到 `master` 后，Auto Tag 已正确汇合同一 source SHA 的 CI、Coverage、Docs 与 Prek，但在 tag 创建前的 distribution preflight 中失败：`verify-artifacts` 执行 Pillow/Skia wheel smoke 时，`skia-python` 因 runner 缺少 `libEGL.so.1` 无法导入。tag 创建和 Publish dispatch 均被安全跳过，`v0.8.0` 未进入发布链。

根因不是包实现，而是 Skia 的 Linux runtime libraries 只在部分 CI jobs 中重复安装，Auto Tag、TestPyPI 与正式 Publish 的构建 job 没有共享同一前置条件。与此同时，旧 Auto Tag 只识别 merge commit 上的版本变化；基础设施修复落到后续 `master` SHA 后无法重新 cut 同一未发布版本，且 Docs path filter 可能让恢复 SHA 缺少 exact-SHA 门禁。

本 PR 将版本推进到 `0.8.1`，修复 distribution verification 的系统依赖所有权，并补齐不绕过既有发布不变量的 pre-tag recovery。

## 方案

### 统一 distribution smoke 环境

- 新增仓库内复用的 `setup-skia-runtime` composite action，集中安装 `libegl1`、`libexpat1` 与 `libgl1`；
- CI package、wheel matrix、Coverage、Auto Tag、TestPyPI 与正式 Publish 全部使用同一 action；
- 保留真实 Pillow/Skia raster smoke，不通过跳过 Skia、捕获导入错误或放宽 `verify-artifacts` 来规避环境缺失。

### 受约束的 pre-tag recovery

- 为 Auto Tag 增加显式 `workflow_dispatch`，要求输入完整 `source_sha`；
- recovery 只接受默认分支 workflow definition 与当前 `master` tip，不允许选择历史 commit；
- 创建 tag 前重新汇合该 SHA 的 CI、Coverage、Docs、Prek，校验 source/version/lockfile，并重新构建、检查 wheel 与 sdist；
- recovery 要求目标 tag 尚不存在；已有 tag 的部分失败继续通过 `Publish` 恢复，避免移动或重建 tag；
- Docs 改为覆盖每个 `master` push，使任何可能成为 recovery release source 的 SHA 都具备 exact-SHA 门禁。

### 契约、文档与版本

- 新增 release workflow contract tests，约束 Skia runtime action 的依赖所有权、各 smoke workflow 的接线、recovery 的 tip/tag/gate 不变量以及 Docs 覆盖范围；
- 更新 CI 与发布文档，区分 pre-tag infrastructure recovery 和已有 tag 的 Publish recovery；
- 通过 `uv version` 将 `pyproject.toml` 与 `uv.lock` 同步到 `0.8.1`。

## 行为、兼容性与风险

- 包运行时 API、配置和渲染语义相对 v0.8 架构无变化；用户可见的包差异仅为版本号推进。
- 所有执行 graphics distribution smoke 的 jobs 都运行于 Ubuntu runner；安装系统库会增加少量启动时间和 apt 网络依赖，但消除了不同发布入口的环境漂移。
- Auto Tag 的手动入口仍拥有创建 tag 与 dispatch workflow 所需的写权限，因此恢复路径刻意要求默认分支、完整 SHA、当前 `master` tip、四条成功门禁和不存在的目标 tag。
- 普通无版本变化的 `master` push 仍不会自动创建 tag；手动 recovery 是维护者明确批准后的异常恢复入口，不是常规发布捷径。
- `v0.8.0` 未创建 tag、未上传 PyPI；本 PR 合并后由正常的 `0.8.1` version-change flow 执行发布，不需要手工创建 tag 或直接运行 Publish。

## 验证

- [x] `make ruff-format-check`
- [x] `make ruff-check`
- [x] `make typecheck`：Basedpyright 零诊断，公开包类型完备性 100%
- [x] `make ty`
- [x] `make test-ci`：712 passed、2 skipped，coverage 90%
- [x] `prek run --all-files`：Prettier、zizmor、workflow schema、shell/Markdown/Python hooks 通过
- [x] `prek run actionlint --all-files --hook-stage=manual`
- [x] PR Package Build、Python 3.10–3.14 wheel smoke 与 NoneBot load matrix 通过
- [x] PR Python 3.10–3.14 × x64/arm64 coverage matrix 通过
- [x] PR Remote Browser Render Smoke 通过
- [x] 新增 release workflow contract regression tests

## 文档

- [x] 已更新 CI 与发布恢复文档
- [x] Zensical strict build 与 PR 文档预览通过

## 合并前

- [ ] 将 PR 标题改为可作为 squash commit subject 的 `type(scope): subject`
- [x] 处理阻塞 review，并在实质性更新后重新请求 review
- [x] 分支已同步最新 `master`，当前所有适用 checks 通过
